### PR TITLE
Show duplicate log bug when running RoutesCest.php

### DIFF
--- a/app/config/database.php
+++ b/app/config/database.php
@@ -55,9 +55,9 @@ return array(
 		'mysql' => array(
 			'driver'    => 'mysql',
 			'host'      => 'localhost',
-			'database'  => 'l4-module',
-			'username'  => 'root',
-			'password'  => '',
+			'database'  => 'l4_module',
+			'username'  => 'homestead',
+			'password'  => 'secret',
 			'charset'   => 'utf8',
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',

--- a/app/controllers/PostsController.php
+++ b/app/controllers/PostsController.php
@@ -21,6 +21,8 @@ class PostsController extends BaseController {
      */
     public function index()
     {
+        \Log::info('hitting PostsController@index');
+
         $posts = $this->post->all();
 
         return View::make('posts.index', compact('posts'));


### PR DESCRIPTION
Adding a `\Log::info('hitting PostsController@index')` to the `PostsController@index` creates four logs when running the `RoutesCest.php`. It only creates two logs (correct behavior) after commenting out `$this->fireBootedCallbacks();` in `Codeception\Lib\Connector\Laravel4`

I'm not sure how to fix this, but I wanted to show the problem.  Let me know how I can continue to help.
